### PR TITLE
Update build status badge in README (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
+[![Java CI](https://github.com/AY2425S2-CS2103T-T15-4/tp/actions/workflows/gradle.yml/badge.svg)](https://github.com/AY2425S2-CS2103T-T15-4/tp/actions/workflows/gradle.yml)
 [![codecov](https://codecov.io/gh/AY2425S2-CS2103T-T15-4/tp/graph/badge.svg?token=NCIPSB7D84)](https://codecov.io/gh/AY2425S2-CS2103T-T15-4/tp)
 
 ![Ui](docs/images/Ui.png)


### PR DESCRIPTION
Fixes #14. Updated badge to team repo’s CI status.