### PR TITLE
add district, price, landSize fields with setters to Person (WIP)

### DIFF
--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -26,6 +26,11 @@ public class Person {
     private final Set<Tag> tags = new HashSet<>();
     private final String leadStatus;
     private final Boolean isBuyer;
+    // TODO
+    private final String district = null;
+    private final Integer price = null;
+    private final Integer landSize = null;
+
     /**
      * Every field must be present and not null.
      */
@@ -77,6 +82,18 @@ public class Person {
     }
     public Boolean getIsBuyer() {
         return isBuyer;
+    }
+
+    public String getDistrict() {
+        return district;
+    }
+
+    public int getPrice() {
+        return price;
+    }
+
+    public int getLandSize() {
+        return landSize;
     }
 
     /**


### PR DESCRIPTION
### Motivation
Real estate agents need to track property details for contacts in ConnectEase. The current `Person` model lacks fields for district, price, and land size, limiting its utility for v1.4.

### Changes
- Added optional fields to `Person.java`:
  - `district` (String, e.g., "D15") for property district.
  - `price` (int, e.g., 2500000) for property value in SGD.
  - `landSize` (int, e.g., 1200) for land area in sqft.
- Added setters (`setDistrict`, `setPrice`, `setLandSize`) to avoid constructor changes.

### TODO
- [ ] Update `AddCommand` to set new fields during execution.
- [ ] Update `AddCommandParser` to parse new prefixes: `d/`, `pr/`, `ls/`.
- [ ] Add prefixes to `CliSyntax.java`.
- [ ] Test manually:
  - `a n/John Doe p/98765432 d/D15 pr/2500000 ls/1200` → Adds person with property fields.
  - `a n/Alice Tan d/D10` → Adds person with district only.
- [ ] Update tests (e.g., `AddCommandTest`) to reflect new fields.

### Testing
- Build: `./gradlew build` (tests may fail due to unchanged `AddCommand`).
- No manual tests yet—pending `add` command updates.

Closes #41