### PR TITLE
Matchcommand/04 added equals (#43)

### DIFF
--- a/src/main/java/seedu/address/logic/commands/MatchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MatchCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.function.Predicate;
 
+import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -89,6 +90,16 @@ public class MatchCommand extends Command {
                 && person.getDistrict().equals(otherMatch.person.getDistrict())
                 && person.getLandSize().equals(otherMatch.person.getLandSize())
                 && person.getPrice().equals(otherMatch.person.getPrice());
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("isBuyer", person.getIsBuyer())
+                .add("district", person.getDistrict())
+                .add("landSize", person.getLandSize())
+                .add("price", person.getPrice())
+                .toString();
     }
 }
 

--- a/src/main/java/seedu/address/logic/commands/MatchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MatchCommand.java
@@ -1,0 +1,78 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Predicate;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+
+/**
+ * Filters and displays persons that match the housing criteria
+ * of the person at the specified index.
+ */
+public class MatchCommand extends Command {
+
+    public static final String COMMAND_WORD = "match";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Finds and displays all persons matching the attributes of the person at the specified index.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    private final Person person;
+
+    public MatchCommand(Person person) {
+        this.person = person;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        Predicate<Person> matchPredicate = getMatchPredicate(person);
+        model.updateFilteredPersonList(matchPredicate);
+
+        int matchCount = model.getFilteredPersonList().size();
+        return new CommandResult(String.format(Messages.MESSAGE_PERSONS_MATCH_OVERVIEW, matchCount));
+    }
+
+    private Predicate<Person> getMatchPredicate(Person person) {
+        return candidate -> {
+            if (person.getIsBuyer() == null || candidate.getIsBuyer() == null) {
+                return false;
+            }
+
+            if (person.getDistrict() == null
+                    || candidate.getDistrict() == null
+                    || person.getLandSize() == null
+                    || candidate.getLandSize() == null
+                    || person.getPrice() == null
+                    || candidate.getPrice() == null) {
+                return false;
+            }
+
+            if (person.getIsBuyer()) {
+                if (candidate.getIsBuyer()) {
+                    return false;
+                }
+
+                return person.getDistrict().equals(candidate.getDistrict())
+                        && candidate.getLandSize() >= person.getLandSize()
+                        && candidate.getPrice() <= person.getPrice();
+            } else {
+                if (!candidate.getIsBuyer()) {
+                    return false;
+                }
+
+                return person.getDistrict().equals(candidate.getDistrict())
+                        && candidate.getLandSize() <= person.getLandSize()
+                        && candidate.getPrice() >= person.getPrice();
+            }
+        };
+    }
+}
+

--- a/src/main/java/seedu/address/logic/commands/MatchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MatchCommand.java
@@ -74,5 +74,21 @@ public class MatchCommand extends Command {
             }
         };
     }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof MatchCommand)) {
+            return false;
+        }
+
+        MatchCommand otherMatch = (MatchCommand) other;
+        return person.getIsBuyer().equals(otherMatch.person.getIsBuyer())
+                && person.getDistrict().equals(otherMatch.person.getDistrict())
+                && person.getLandSize().equals(otherMatch.person.getLandSize())
+                && person.getPrice().equals(otherMatch.person.getPrice());
+    }
 }
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -6,7 +6,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Predicate;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.tag.Tag;
@@ -156,30 +155,6 @@ public class Person {
         //            builder.add("isBuyer", isBuyer);
         //        }
         return builder.toString();
-    }
-
-    private Predicate<Person> getMatchPredicate(Person person) {
-        return candidate -> {
-            if (person.getIsBuyer() == null || candidate.getIsBuyer() == null) return false;
-
-            if (person.getDistrict() == null || candidate.getDistrict() == null ||
-                    person.getLandSize() == null || candidate.getLandSize() == null ||
-                    person.getPrice() == null || candidate.getPrice() == null) return false;
-
-            if (person.getIsBuyer()) {
-                if (candidate.getIsBuyer()) return false;
-
-                return person.getDistrict().equals(candidate.getDistrict())
-                        && candidate.getLandSize() >= person.getLandSize()
-                        && candidate.getPrice() <= person.getPrice();
-            } else {
-                if (!candidate.getIsBuyer()) return false;
-
-                return person.getDistrict().equals(candidate.getDistrict())
-                        && candidate.getLandSize() <= person.getLandSize()
-                        && candidate.getPrice() >= person.getPrice();
-            }
-        };
     }
 
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.tag.Tag;
@@ -155,6 +156,30 @@ public class Person {
         //            builder.add("isBuyer", isBuyer);
         //        }
         return builder.toString();
+    }
+
+    private Predicate<Person> getMatchPredicate(Person person) {
+        return candidate -> {
+            if (person.getIsBuyer() == null || candidate.getIsBuyer() == null) return false;
+
+            if (person.getDistrict() == null || candidate.getDistrict() == null ||
+                    person.getLandSize() == null || candidate.getLandSize() == null ||
+                    person.getPrice() == null || candidate.getPrice() == null) return false;
+
+            if (person.getIsBuyer()) {
+                if (candidate.getIsBuyer()) return false;
+
+                return person.getDistrict().equals(candidate.getDistrict())
+                        && candidate.getLandSize() >= person.getLandSize()
+                        && candidate.getPrice() <= person.getPrice();
+            } else {
+                if (!candidate.getIsBuyer()) return false;
+
+                return person.getDistrict().equals(candidate.getDistrict())
+                        && candidate.getLandSize() <= person.getLandSize()
+                        && candidate.getPrice() >= person.getPrice();
+            }
+        };
     }
 
 }


### PR DESCRIPTION
Adds an equals(...) method to MatchCommand, allowing logical comparisons between instances.

The comparison checks equality based on: isBuyer flag, district, landSize, price
This enables reliable testing, undo/redo support, and deduplication when needed.