### PR TITLE
feat(fuzzy): enhance MultiFieldFuzzyPredicate with assertions, logging, and exceptions and fixed checkstyle for AddPropertyCommand and EditCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddPropertyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPropertyCommand.java
@@ -1,16 +1,18 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRICE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
-import static java.util.Objects.requireNonNull;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.property.Property;
 
-
+/**
+ * Represents a command to add a property to the address book.
+ */
 public class AddPropertyCommand extends Command {
     public static final String COMMAND_WORD = "add-property";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a property to the address book.\n"
@@ -29,10 +31,15 @@ public class AddPropertyCommand extends Command {
 
     private final Property toAdd;
 
+    /**
+     * Creates an {@code AddPropertyCommand} to add the specified {@code Property}
+     * @param property The property to be added.
+     */
     public AddPropertyCommand(Property property) {
         requireNonNull(property);
         toAdd = property;
     }
+
 
     @Override
     public CommandResult execute(Model model) throws CommandException {

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -117,7 +117,8 @@ public class EditCommand extends Command {
         Price updatedprice = editPersonDescriptor.getPrice().orElse(personToEdit.getPrice());
         LandSize updatedlandSize = editPersonDescriptor.getLandSize().orElse(personToEdit.getLandSize());
 
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, null, updatedClientType, updateddistrict, updatedprice, updatedlandSize);
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, null,
+                updatedClientType, updateddistrict, updatedprice, updatedlandSize);
     }
 
     @Override
@@ -181,7 +182,8 @@ public class EditCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone, email, address, tags, clientType, district, price, landSize);
+            return CollectionUtil.isAnyNonNull(name, phone, email, address, tags,
+                    clientType, district, price, landSize);
         }
 
         public void setName(Name name) {
@@ -216,21 +218,37 @@ public class EditCommand extends Command {
             return Optional.ofNullable(address);
         }
 
-        public void setClientType(ClientType clienttype) { this.clientType = clienttype; }
+        public void setClientType(ClientType clienttype) {
+            this.clientType = clienttype;
+        }
 
-        public Optional<ClientType> getClientType() { return Optional.ofNullable(clientType);}
+        public Optional<ClientType> getClientType() {
+            return Optional.ofNullable(clientType);
+        }
 
-        public void setDistrict(District district) { this.district = district; }
+        public void setDistrict(District district) {
+            this.district = district;
+        }
 
-        public Optional<District> getDistrict() { return Optional.ofNullable(district);}
+        public Optional<District> getDistrict() {
+            return Optional.ofNullable(district);
+        }
 
-        public void setPrice(Price price) { this.price = price; }
+        public void setPrice(Price price) {
+            this.price = price;
+        }
 
-        public Optional<Price> getPrice() { return Optional.ofNullable(price);}
+        public Optional<Price> getPrice() {
+            return Optional.ofNullable(price);
+        }
 
-        public void setLandSize(LandSize landSize) { this.landSize = landSize; }
+        public void setLandSize(LandSize landSize) {
+            this.landSize = landSize;
+        }
 
-        public Optional<LandSize> getLandSize() { return Optional.ofNullable(landSize);}
+        public Optional<LandSize> getLandSize() {
+            return Optional.ofNullable(landSize);
+        }
 
 
 

--- a/src/main/java/seedu/address/model/person/MultiFieldFuzzyPredicate.java
+++ b/src/main/java/seedu/address/model/person/MultiFieldFuzzyPredicate.java
@@ -1,7 +1,13 @@
 package seedu.address.model.person;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.logging.Logger;
+
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.person.exceptions.InvalidPredicateException;
 
 /**
  * Tests that a {@code Person}'s name, phone, or email matches any of the given keywords.
@@ -9,26 +15,69 @@ import java.util.function.Predicate;
  * Matching is case-insensitive.
  */
 public class MultiFieldFuzzyPredicate implements Predicate<Person> {
+    private static final Logger logger = LogsCenter.getLogger(MultiFieldFuzzyPredicate.class.getName());
+    public static final int MAX_LEVENSHTEIN_DISTANCE = 2;
+    public static final String MESSAGE_EMPTY_KEYWORDS = "Keywords list cannot be empty.";
+
     private final List<String> keywords;
 
-    public MultiFieldFuzzyPredicate(List<String> keywords) {
+    /**
+     * Constructs a predicate with the given keywords.
+     * @param keywords List of keywords to match against.
+     */
+    public MultiFieldFuzzyPredicate(List<String> keywords) throws InvalidPredicateException {
+        requireNonNull(keywords, "Keywords list must not be null");
+        if (keywords.isEmpty()) {
+            logger.warning("Attempted to create MultiFieldFuzzyPredicate with empty keywords");
+            throw new InvalidPredicateException(MESSAGE_EMPTY_KEYWORDS);
+        }
         this.keywords = keywords;
+        logger.fine("Initialized MultiFieldFuzzyPredicate with keywords: " + keywords);
     }
 
     @Override
     public boolean test(Person person) {
+        requireNonNull(person, "Person must not be null");
+        assert person.getName() != null : "Person name must not be null";
+
         return keywords.stream().anyMatch(keyword -> {
             String lowerKeyword = keyword.toLowerCase();
+            logger.finer("Testing keyword: " + lowerKeyword);
+
+            // Name matching (fuzzy)
             String lowerName = person.getName().toString().toLowerCase();
-            return lowerName.contains(lowerKeyword)
-                    || isFuzzyMatch(lowerName, lowerKeyword)
-                    || (person.getPhone() != null && person.getPhone().toString().contains(lowerKeyword))
-                    || (person.getEmail() != null && person.getEmail().toString().contains(lowerKeyword));
+            boolean nameMatch = lowerName.contains(lowerKeyword) || isFuzzyMatch(lowerName, lowerKeyword);
+            if (nameMatch) {
+                logger.fine("Name match found: " + lowerName + " with " + lowerKeyword);
+                return true;
+            }
+
+            // Phone matching (substring)
+            assert person.getPhone() != null : "Person phone must not be null";
+            boolean phoneMatch = person.getPhone().toString().contains(lowerKeyword);
+            if (phoneMatch) {
+                logger.fine("Phone match found: " + person.getPhone() + " with " + lowerKeyword);
+                return true;
+            }
+
+            // Email matching (substring)
+            assert person.getEmail() != null : "Person email must not be null";
+            boolean emailMatch = person.getEmail().toString().contains(lowerKeyword);
+            if (emailMatch) {
+                logger.fine("Email match found: " + person.getEmail() + " with " + lowerKeyword);
+                return true;
+            }
+
+            return false;
         });
     }
 
     private boolean isFuzzyMatch(String source, String target) {
-        return levenshtein(source, target) <= 2; // Allow up to 2 edits
+        requireNonNull(source, "Source string must not be null");
+        requireNonNull(target, "Target string must not be null");
+        int distance = levenshtein(source, target);
+        logger.finer("Levenshtein distance between '" + source + "' and '" + target + "': " + distance);
+        return distance <= MAX_LEVENSHTEIN_DISTANCE;
     }
 
     private int levenshtein(String s1, String s2) {
@@ -50,8 +99,23 @@ public class MultiFieldFuzzyPredicate implements Predicate<Person> {
 
     @Override
     public boolean equals(Object other) {
-        return other == this
-                || (other instanceof MultiFieldFuzzyPredicate
-                && keywords.equals(((MultiFieldFuzzyPredicate) other).keywords));
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof MultiFieldFuzzyPredicate otherPredicate)) {
+            return false;
+        }
+        return keywords.equals(otherPredicate.keywords);
+    }
+
+    private static void requireNonNull(Object obj, String message) {
+        if (obj == null) {
+            logger.severe("Null detected: " + message);
+            throw new NullPointerException(message);
+        }
+    }
+
+    public List<String> getKeywords() {
+        return keywords;
     }
 }

--- a/src/main/java/seedu/address/model/person/exceptions/InvalidPredicateException.java
+++ b/src/main/java/seedu/address/model/person/exceptions/InvalidPredicateException.java
@@ -1,0 +1,7 @@
+package seedu.address.model.person.exceptions;
+
+public class InvalidPredicateException extends RuntimeException {
+    public InvalidPredicateException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
### Summary
Improves `MultiFieldFuzzyPredicate` with assertions, logging, exceptions, and defensive coding for v1.4 alpha testing.

### Changes
- Added assertions for non-null fields.
- Integrated logging for debugging.
- Throws `InvalidPredicateException` for empty keywords.
- Centralized null checks with `requireNonNull`.

### Testing
- Run `f ""`—expect exception.
- Add person, run `f sara`—check logs.

Fixes #69.
